### PR TITLE
`grep -v` before `awk`

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -45,7 +45,7 @@
     <p>
     Can't do it? See <a href="/display/2">my workflow </a>
     </p>
-    <pre> history | grep "  git " | awk '{print $1 " " $3}' | grep -v '|' > history.txt </pre>
+    <pre> history | grep "  git " | grep -v '|' | awk '{print $1 " " $3}' > history.txt </pre>
     The result is a graph of which commands you use after other
     commands. For example, if you always push after committing, there
     will be a big arrow from 'commit' to 'push'.


### PR DESCRIPTION
Move `grep -v` before `awk` since `awk` will probably not print any `|`s.
